### PR TITLE
Fix #14: Parse incomplete HTTP status codes

### DIFF
--- a/include/hackney_lib.hrl
+++ b/include/hackney_lib.hrl
@@ -13,3 +13,20 @@
 
 %% common types
 -type hackney_url() :: #hackney_url{}.
+
+
+-record(hparser, {type=auto,
+                  max_line_length=4096,
+                  max_empty_lines=10,
+                  empty_lines=0,
+                  state=on_first_line,
+                  buffer = <<>>,
+                  version,
+                  method,
+                  partial_headers=[],
+                  clen,
+                  te,
+                  connection,
+                  ctype,
+                  location,
+                  body_state=waiting}).

--- a/test/hackney_http_tests.erl
+++ b/test/hackney_http_tests.erl
@@ -1,0 +1,17 @@
+-module(hackney_http_tests).
+-include_lib("eunit/include/eunit.hrl").
+-include("hackney_lib.hrl").
+
+parse_response_correct_200_test() ->
+	Response = <<"HTTP/1.1 200 OK">>,
+	St = #hparser{},
+	{response, Version, StatusInt, Reason, NState} = hackney_http:parse_response_line(Response, St),
+	?assertEqual(StatusInt, 200),
+	?assertEqual(Reason, <<"OK">>).
+
+parse_response_incomplete_200_test() ->
+	Response = <<"HTTP/1.1 200 ">>,
+	St = #hparser{},
+	{response, _Version, StatusInt, Reason, _NState} = hackney_http:parse_response_line(Response, St),
+	?assertEqual(StatusInt, 200),
+	?assertEqual(Reason, <<"">>).


### PR DESCRIPTION
The fix works but the changes needed for testing it
are probably not what you want. I suppose in order to
prevent any changes in hackney_http, I'd need to do the
tests inline but as I didn't see this in the other source code I decided
to make an outside test working.

However I think you might not like these changes, therefore
please guide me what would be the best option.

Also I think there might be a better naming for the case variables. If you have some
suggestions, please tell me.

(This fixes #14 - apparently github doesn't parse subject lines in PRs, so I added this line to add the link)
