### PR TITLE
Fix "exception error: bad argument" for hackney_url:fix_path(<<"/">>)

### DIFF
--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -300,6 +300,8 @@ make_url(Url, PathParts, Query) when is_binary(Query) ->
 
 fix_path(Path) when is_list(Path) ->
     fix_path(list_to_binary(Path));
+fix_path(<<>>) -> 
+    <<>>;
 fix_path(<<"/", Path/binary>>) ->
     fix_path(Path);
 fix_path(Path) ->


### PR DESCRIPTION
Fix "exception error: bad argument" for hackney_url:fix_path(<<"/">>) or hackney_url:fix_path(<<>>);

Error was:
(wsg@alg)30> hackney_url:fix_path(<<"/">>).
(<0.2999.0>) call hackney_url:fix_path(<<"/">>)
(<0.2999.0>) call hackney_url:fix_path(<<>>)
(<0.2999.0>) exception_from {hackney_url,fix_path,1} {error,badarg}
(<0.2999.0>) exception_from {hackney_url,fix_path,1} {error,badarg}
*\* exception error: bad argument
     in function  binary:part/2
        called as binary:part(<<>>,{0,-1})
     in call from hackney_url:fix_path/1 (src/hackney_url.erl, line 306)
