### PR TITLE
fixed a bug where an empty path part would cause make_url/3 to fail

### DIFF
--- a/src/hackney_url.erl
+++ b/src/hackney_url.erl
@@ -286,7 +286,7 @@ make_url(Url, Path, Query) when is_binary(Path) ->
     make_url(Url, [Path], Query);
 make_url(Url, PathParts, Query) when is_binary(Query) ->
     %% create path
-    PathParts1 = [fix_path(P) || P <- PathParts, P /= "/" orelse P /= <<"/">>],
+    PathParts1 = [fix_path(P) || P <- PathParts, P /= "", P /= "/" orelse P /= <<"/">>],
     Path = hackney_bstr:join([<<>> | PathParts1], <<"/">>),
 
     %% initialise the query


### PR DESCRIPTION
starting e.g. couchbeam pointing at "localhost:5984" would fail because part of the path is the empty string.  this patch fixes that "bug".
