### PR TITLE
Remove unicode from applications list in .app.src

### DIFF
--- a/src/hackney_lib.app.src
+++ b/src/hackney_lib.app.src
@@ -6,7 +6,7 @@
         {description, "Web toolkit"},
         {vsn, "0.3.0"},
         {registered, []},
-        {applications, [kernel, stdlib, unicode, idna]},
+        {applications, [kernel, stdlib, idna]},
         {included_applications, []},
         {env, []}
 ]}.


### PR DESCRIPTION
There is no longer a recursive dependency named unicode, so that application does not exist. Listing it broke release generation with rebar_reltool in new builds of applications which depend on hackney_lib.
