### PR TITLE
Remove unicode from applications key

### DIFF
--- a/src/hackney_lib.app.src
+++ b/src/hackney_lib.app.src
@@ -6,7 +6,7 @@
         {description, "Web toolkit"},
         {vsn, "0.3.0"},
         {registered, []},
-        {applications, [kernel, stdlib, unicode, idna]},
+        {applications, [kernel, stdlib, idna]},
         {included_applications, []},
         {env, []}
 ]}.


### PR DESCRIPTION
`unicode` is included in the `stdlib` application, and doesn't exist as an application (it's just a module). This is causing releases with relx to fail since it can't resolve that dependency. This removes `unicode` from the applications key in `hackney_lib.app.src`.
